### PR TITLE
Add shared API key authentication for MCP server

### DIFF
--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from "express";
+
+export function loadAllowedApiKeys(envVar: string = "MCP_API_KEYS"): Set<string> {
+  const rawKeys = process.env[envVar];
+
+  if (!rawKeys) {
+    throw new Error(`${envVar} environment variable must be set with at least one API key`);
+  }
+
+  const keys = rawKeys
+    .split(",")
+    .map((key) => key.trim())
+    .filter((key) => key.length > 0);
+
+  if (keys.length === 0) {
+    throw new Error(`${envVar} environment variable must contain at least one non-empty API key`);
+  }
+
+  return new Set(keys);
+}
+
+export function createApiKeyAuthMiddleware(allowedApiKeys: Set<string>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    let token: string | undefined;
+
+    if (authHeader?.startsWith("Bearer ")) {
+      token = authHeader.substring("Bearer ".length).trim();
+    }
+
+    if (!token) {
+      const apiKeyHeader = req.header("x-api-key");
+      if (apiKeyHeader) {
+        token = apiKeyHeader.trim();
+      }
+    }
+
+    if (!token || !allowedApiKeys.has(token)) {
+      res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message: "Unauthorized",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,7 @@ initializeFieldConfiguration();
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
-const server = initMcpServer(process.env.DATAFORSEO_USERNAME, process.env.DATAFORSEO_PASSWORD);
+const server = initMcpServer();
 
 // Start the server
 async function main() {

--- a/src/main/init-mcp-server.ts
+++ b/src/main/init-mcp-server.ts
@@ -6,19 +6,37 @@ import { BaseModule, ToolDefinition } from "../core/modules/base.module.js";
 import { z } from 'zod';
 import { name, version } from '../core/utils/version.js';
 
+let cachedDataForSeoConfig: DataForSEOConfig | null = null;
 
-export function initMcpServer(username: string | undefined, password: string | undefined): McpServer {
+function loadDataForSeoConfig(): DataForSEOConfig {
+  if (cachedDataForSeoConfig) {
+    return cachedDataForSeoConfig;
+  }
+
+  const username = process.env.DATAFORSEO_USERNAME?.trim();
+  const password = process.env.DATAFORSEO_PASSWORD?.trim();
+
+  if (!username || !password) {
+    throw new Error("DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD environment variables must be set and non-empty");
+  }
+
+  cachedDataForSeoConfig = {
+    username,
+    password,
+  };
+
+  return cachedDataForSeoConfig;
+}
+
+export function initMcpServer(): McpServer {
   const server = new McpServer({
     name,
     version,
   }, { capabilities: { logging: {} } });
 
   // Initialize DataForSEO client
-  const dataForSEOConfig: DataForSEOConfig = {
-    username: username || "",
-    password: password || "",
-  };
-  
+  const dataForSEOConfig = loadDataForSeoConfig();
+
   const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
   console.error('DataForSEO client initialized');
   


### PR DESCRIPTION
## Summary
- add configuration helper to load allowed API keys and shared authentication middleware
- enforce bearer/x-api-key validation on HTTP and SSE entrypoints while removing request-scoped DataForSEO credentials
- initialize MCP server instances with the service account credentials sourced from environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4e878ca3c8325b6b71554605383d5