### PR TITLE
Validate DataForSEO credentials before initializing MCP server

### DIFF
--- a/src/main/index-http.ts
+++ b/src/main/index-http.ts
@@ -18,7 +18,7 @@ import { GetPromptResult, isInitializeRequest, ReadResourceResult, ServerNotific
 import { name, version } from '../core/utils/version.js';
 import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
-import { initMcpServer } from "./init-mcp-server.js";
+import { getValidatedDataForSeoConfig, initMcpServer } from "./init-mcp-server.js";
 import { createApiKeyAuthMiddleware, loadAllowedApiKeys } from "./auth.js";
 
 // Initialize field configuration if provided
@@ -45,7 +45,8 @@ async function main() {
     
     try {
       
-      const server = initMcpServer();
+      const dataForSeoConfig = getValidatedDataForSeoConfig();
+      const server = initMcpServer(dataForSeoConfig);
       console.error(Date.now().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({

--- a/src/main/index-sse-http.ts
+++ b/src/main/index-sse-http.ts
@@ -12,7 +12,7 @@ import { name, version } from '../core/utils/version.js';
 import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
 import { ModuleLoaderService } from '../core/utils/module-loader.js';
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
-import { initMcpServer } from './init-mcp-server.js';
+import { getValidatedDataForSeoConfig, initMcpServer } from './init-mcp-server.js';
 import { createApiKeyAuthMiddleware, loadAllowedApiKeys } from './auth.js';
 
 // Initialize field configuration if provided
@@ -84,7 +84,8 @@ const handleMcpRequest = async (req: Request, res: Response) => {
     try {
       console.error(Date.now().toLocaleString())
       
-      const server = initMcpServer();
+      const dataForSeoConfig = getValidatedDataForSeoConfig();
+      const server = initMcpServer(dataForSeoConfig);
       console.error(Date.now().toLocaleString())
 
       const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
@@ -171,7 +172,8 @@ app.get('/sse', authenticate, async (req: Request, res: Response) => {
   // Set socket timeout
   req.socket.setTimeout(CONNECTION_TIMEOUT);
 
-  const server = initMcpServer();
+  const dataForSeoConfig = getValidatedDataForSeoConfig();
+  const server = initMcpServer(dataForSeoConfig);
   await server.connect(transport);
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,14 +8,15 @@ import { z } from 'zod';
 import { ModuleLoaderService } from "../core/utils/module-loader.js";
 import { initializeFieldConfiguration } from '../core/config/field-configuration.js';
 import { name, version } from '../core/utils/version.js';
-import { initMcpServer } from "./init-mcp-server.js";
+import { getValidatedDataForSeoConfig, initMcpServer } from "./init-mcp-server.js";
 
 // Initialize field configuration if provided
 initializeFieldConfiguration();
 console.error('Starting DataForSEO MCP Server...');
 console.error(`Server name: ${name}, version: ${version}`);
 
-const server = initMcpServer();
+const dataForSeoConfig = getValidatedDataForSeoConfig();
+const server = initMcpServer(dataForSeoConfig);
 
 // Start the server
 async function main() {

--- a/src/main/init-mcp-server.ts
+++ b/src/main/init-mcp-server.ts
@@ -8,7 +8,7 @@ import { name, version } from '../core/utils/version.js';
 
 let cachedDataForSeoConfig: DataForSEOConfig | null = null;
 
-function loadDataForSeoConfig(): DataForSEOConfig {
+export function getValidatedDataForSeoConfig(): DataForSEOConfig {
   if (cachedDataForSeoConfig) {
     return cachedDataForSeoConfig;
   }
@@ -17,7 +17,7 @@ function loadDataForSeoConfig(): DataForSEOConfig {
   const password = process.env.DATAFORSEO_PASSWORD?.trim();
 
   if (!username || !password) {
-    throw new Error("DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD environment variables must be set and non-empty");
+    throw new Error('Missing DataForSEO credentials. Set both DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD environment variables.');
   }
 
   cachedDataForSeoConfig = {
@@ -28,16 +28,14 @@ function loadDataForSeoConfig(): DataForSEOConfig {
   return cachedDataForSeoConfig;
 }
 
-export function initMcpServer(): McpServer {
+export function initMcpServer(config: DataForSEOConfig = getValidatedDataForSeoConfig()): McpServer {
   const server = new McpServer({
     name,
     version,
   }, { capabilities: { logging: {} } });
 
   // Initialize DataForSEO client
-  const dataForSEOConfig = loadDataForSeoConfig();
-
-  const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
+  const dataForSEOClient = new DataForSEOClient(config);
   console.error('DataForSEO client initialized');
   
   // Parse enabled modules from environment

--- a/src/worker/index-worker.ts
+++ b/src/worker/index-worker.ts
@@ -39,9 +39,16 @@ export class DataForSEOMcpAgent extends McpAgent {
     }
 
     // Initialize DataForSEO client
+    const username = workerEnv.DATAFORSEO_USERNAME?.trim();
+    const password = workerEnv.DATAFORSEO_PASSWORD?.trim();
+
+    if (!username || !password) {
+      throw new Error('Missing DataForSEO credentials in worker environment. Set DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD.');
+    }
+
     const dataForSEOConfig: DataForSEOConfig = {
-      username: workerEnv.DATAFORSEO_USERNAME || "",
-      password: workerEnv.DATAFORSEO_PASSWORD || "",
+      username,
+      password,
     };
     
     const dataForSEOClient = new DataForSEOClient(dataForSEOConfig);
@@ -101,7 +108,7 @@ export default {
       });
     }
     // Check if credentials are configured
-    if (!env.DATAFORSEO_USERNAME || !env.DATAFORSEO_PASSWORD) {
+    if (!env.DATAFORSEO_USERNAME?.trim() || !env.DATAFORSEO_PASSWORD?.trim()) {
       if (['/mcp','/http', '/sse', '/messages','/sse/message'].includes(url.pathname)) {
         return createErrorResponse(-32001, "DataForSEO credentials not configured in worker environment variables");
       }


### PR DESCRIPTION
## Summary
- add a shared helper to validate DataForSEO credentials and use it before creating MCP servers
- require trimmed credentials in both HTTP entrypoints and the SSE server
- ensure the worker version throws when credentials are missing instead of defaulting to empty strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4edd006a48325b86d2ef55e11aaf8