### PR TITLE
Fix YouTube organic SERP tool request

### DIFF
--- a/src/core/modules/serp/tools/serp-youtube-organic-live-advanced.tool.ts
+++ b/src/core/modules/serp/tools/serp-youtube-organic-live-advanced.tool.ts
@@ -7,6 +7,10 @@ export class SerpYoutubeOrganicLiveAdvancedTool extends BaseTool {
     super(dataForSEOClient);
   }
 
+  protected supportOnlyFullResponse(): boolean {
+    return true;
+  }
+
   getName(): string {
     return 'serp_youtube_organic_live_advanced';
   }
@@ -45,15 +49,30 @@ max value: 700`)
 
   async handle(params:any): Promise<any> {
     try {
-      console.error(JSON.stringify(params, null, 2));
-      const response = await this.dataForSEOClient.makeRequest(`/v3/serp/youtube/organic/live/advanced`, 'POST', [{
+      const payload: Record<string, unknown> = {
         keyword: params.keyword,
         location_name: params.location_name,
         language_code: params.language_code,
-        device: params.device,
-        os: params.os,
-        block_depth: params.block_depth,
-      }]);
+      };
+
+      if (params.device) {
+        payload.device = params.device;
+      }
+
+      if (params.os) {
+        payload.os = params.os;
+      }
+
+      if (typeof params.block_depth !== 'undefined') {
+        payload.block_depth = params.block_depth;
+      }
+
+      const response = await this.dataForSEOClient.makeRequest(
+        `/v3/serp/youtube/organic/live/advanced`,
+        'POST',
+        [payload],
+        true,
+      );
       return this.validateAndFormatResponse(response);
     } catch (error) {
       return this.formatErrorResponse(error);


### PR DESCRIPTION
## Summary
- ensure the YouTube organic live advanced tool requests the full-response endpoint to avoid HTTP 500 errors
- clean up the request payload by sending only defined parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e513008d6083259fe9f60d2f2bf792